### PR TITLE
Allow newer versions of antlr4-python3-runtime

### DIFF
--- a/google-fhir-core/setup.py
+++ b/google-fhir-core/setup.py
@@ -100,7 +100,7 @@ def main():
       python_requires='>=3.8, <3.12',
       install_requires=[
           'absl-py~=1.1',
-          'antlr4-python3-runtime~=4.9.3',
+           'antlr4-python3-runtime>=4.9.3',
           'backports.zoneinfo~=0.2.1;python_version<"3.9"',
           'immutabledict~=2.2',
           'protobuf~=4.23',


### PR DESCRIPTION
The current version pin `antlr4-python3-runtime~=4.9.3` restricts to only `>=4.9.3, <4.10.0`, making it difficult to include this package in repositories using newer versions of `antlr4-python3-runtime` (e.g., 4.13.x).
This PR relaxes the constraint to `>=4.9.3`, allowing any backward-compatible newer version.
## Changes
- `google-fhir-core/setup.py`: Changed `antlr4-python3-runtime~=4.9.3` to `antlr4-python3-runtime>=4.9.3`
Closes #363